### PR TITLE
Update KIOSC_SERVER_VERSION

### DIFF
--- a/env.example
+++ b/env.example
@@ -4,7 +4,7 @@ NETWORK_BRIDGE_NAME=br-kiosc-public
 
 # Image versions -------------------------------------------------------------
 
-KIOSC_SERVER_VERSION=main-0
+KIOSC_SERVER_VERSION=main
 REDIS_VERSION=8
 TRAEFIK_VERSION=v3
 


### PR DESCRIPTION
`main-0` is no longer maintained, we should use `main` instead.