### PR TITLE
Update KIOSC_SERVER_VERSION

### DIFF
--- a/env.example
+++ b/env.example
@@ -4,7 +4,7 @@ NETWORK_BRIDGE_NAME=br-kiosc-public
 
 # Image versions -------------------------------------------------------------
 
-KIOSC_SERVER_VERSION=main
+KIOSC_SERVER_VERSION=v0.5.2-0
 REDIS_VERSION=8
 TRAEFIK_VERSION=v3
 


### PR DESCRIPTION
In #20 I updated the `KIOSC_SERVER_VERSION` variable from `main-0` to `main`. Since then, I learned that the `-0` suffix represents the build number, which in principle can be updated even if the software version stays the same. This is a best practice used throughout the Sodarverse to tag Docker images with the build number, so we should adopt it for the Kiosc repository, too. With this PR, the version is pinned to `v0.5.2-0`.

Note: so far, building and tagging the image with the build number is not automated and must be done manually by running the `docker/build_docker.sh` script from the [kiosc-server](https://github.com/bihealth/kiosc-server) repository and subsequently pushing the image to ghcr.io.