### PR TITLE
Add custom container registry

### DIFF
--- a/config/registry/config.yml
+++ b/config/registry/config.yml
@@ -2,7 +2,7 @@ version: 0.1
 log:
   accesslog:
     disabled: false
-  # level: debug
+  level: warn
   formatter: text
   fields:
     service: registry
@@ -20,15 +20,15 @@ http:
     X-Content-Type-Options: [nosniff]
   # This will be overwritten by an environment variable in docker compose
   secret: kiosc-server
-  debug:
-    addr: :5001
+  # debug:
+  #   addr: :5001
 notifications:
   events:
     includereferences: false
   endpoints:
     - name: kiosc-web
       disabled: false
-      url: http://127.0.0.1:8000/containers/registry
+      url: http://kiosc-web:8000/registry
       headers:
         # This will be overwritten with an environment variable
         # from the docker compose

--- a/config/registry/config.yml
+++ b/config/registry/config.yml
@@ -1,0 +1,48 @@
+version: 0.1
+log:
+  accesslog:
+    disabled: false
+  # level: debug
+  formatter: text
+  fields:
+    service: registry
+storage:
+  cache:
+    blobdescriptor: inmemory
+  filesystem:
+    rootdirectory: /var/lib/registry
+  tag:
+    concurrencylimit: 8
+http:
+  addr: :5000
+  prefix: /
+  headers:
+    X-Content-Type-Options: [nosniff]
+  # This will be overwritten by an environment variable in docker compose
+  secret: kiosc-server
+  debug:
+    addr: :5001
+notifications:
+  events:
+    includereferences: false
+  endpoints:
+    - name: kiosc-web
+      disabled: false
+      url: http://127.0.0.1:8000/containers/registry
+      headers:
+        # This will be overwritten with an environment variable
+        # from the docker compose
+        authorization: ["Bearer REPLACEMEWITHASECRETTOKEN"]
+      timeout: 32s
+      threshold: 3
+      backoff: 4s
+      ignoredmediatypes:
+        - application/octet-stream
+      ignore:
+        mediatypes:
+           - application/octet-stream
+        actions:
+           - pull
+redis:
+  addrs: [redis:6379]
+  db: 0

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,6 +17,23 @@ x-postgres: &default-postgres
       source: ./scripts/init.sql
       target: /docker-entrypoint-initdb.d/init.sql
 
+# Default configuration for Docker registry
+x-kiosc-registry: &default-registry
+  image: registry:3
+  container_name: kiosc-registry
+  restart: unless-stopped
+  environment: &default-registry-environment
+    REGISTRY_NOTIFICATIONS_ENDPOINTS_0_HEADERS_AUTHORIZATION: "[\"Bearer ${KIOSC_CUSTOM_REGISTRY_NOTIFICATIONS_TOKEN}\"]"
+    REGISTRY_HTTP_SECRET: ${KIOSC_CUSTOM_REGISTRY_HTTP_SECRET}
+  volumes:
+    - type: bind
+      source: /var/lib/docker/registry
+      target: /var/lib/registry
+    - type: bind
+      source: ./config/registry/config.yml
+      target: /etc/distribution/config.yml
+      read_only: true
+
 # Default configuration for Kiosc Servers
 x-kiosc: &default-kiosc
   image: ghcr.io/bihealth/kiosc-server:${KIOSC_SERVER_VERSION}
@@ -25,6 +42,7 @@ x-kiosc: &default-kiosc
     LC_ALL: en_US.UTF-8
     # Kiosc configuration
     DATABASE_URL: ${KIOSC_DATABASE_URL}
+    REDIS_URL: ${KIOSC_REDIS_URL}
     DJANGO_ALLOWED_HOSTS: ${KIOSC_DJANGO_ALLOWED_HOSTS}
     DJANGO_SECRET_KEY: ${KIOSC_DJANGO_SECRET_KEY}
     DJANGO_SETTINGS_MODULE: ${KIOSC_DJANGO_SETTINGS_MODULE}
@@ -34,6 +52,9 @@ x-kiosc: &default-kiosc
     KIOSC_DOCKER_WEB_SERVER: ${KIOSC_DOCKER_WEB_SERVER}
     KIOSC_EMBEDDED_FILES: ${KIOSC_EMBEDDED_FILES}
     KIOSC_NETWORK_MODE: ${KIOSC_NETWORK_MODE}
+    KIOSC_DATA_UPLOAD_MAX_MEMORY_SIZE: ${KIOSC_DATA_UPLOAD_MAX_MEMORY_SIZE}
+    KIOSC_CUSTOM_REGISTRY_URL: ${KIOSC_CUSTOM_REGISTRY_URL}
+    KIOSC_CUSTOM_REGISTRY_NOTIFICATIONS_TOKEN: ${KIOSC_CUSTOM_REGISTRY_NOTIFICATIONS_TOKEN}
     CELERY_BROKER_URL: ${KIOSC_CELERY_BROKER_URL}
     UVICORN_WORKERS: ${KIOSC_UVICORN_WORKERS}
     # LDAP auth
@@ -107,8 +128,6 @@ x-kiosc: &default-kiosc
     PROJECTROLES_TEMPLATE_INCLUDE_PATH: ${KIOSC_PROJECTROLES_TEMPLATE_INCLUDE_PATH}
   env_file:
     - .env
-  networks:
-    - kiosc-public
   restart: unless-stopped
   volumes:
     - type: bind
@@ -138,6 +157,17 @@ services:
         source: ./volumes/redis/data
         target: /data
 
+  kiosc-registry:
+    <<: *default-registry
+    environment:
+      <<: *default-registry-environment
+      REGISTRY_NOTIFICATIONS_ENDPOINTS_0_URL: "http://127.0.0.1:8080/containers/registry"
+    profiles: [deploy, dev]
+    ports:
+      - 5000:5000
+    networks:
+      - kiosc-public
+
   traefik:
     image: traefik:${TRAEFIK_VERSION-v3}
     profiles: [deploy]
@@ -165,8 +195,7 @@ services:
   kiosc-web:
     <<: *default-kiosc
     profiles: [deploy]
-    networks:
-      - kiosc-public
+    network_mode: service:kiosc-registry
     restart: unless-stopped
     depends_on:
       - postgres
@@ -183,9 +212,9 @@ services:
   kiosc-celerybeat:
     <<: *default-kiosc
     profiles: [deploy]
-    command: ["celerybeat"]
     networks:
       - kiosc-public
+    command: ["celerybeat"]
     depends_on:
       - kiosc-web
     restart: unless-stopped
@@ -193,6 +222,8 @@ services:
   kiosc-celeryd-default:
     <<: *default-kiosc
     profiles: [deploy]
+    networks:
+        - kiosc-public
     command: ["celeryd"]
     environment:
       <<: *default-kiosc-environment
@@ -200,8 +231,6 @@ services:
       CELERY_WORKERS: 16
     depends_on:
       - kiosc-web
-    networks:
-      - kiosc-public
     restart: unless-stopped
 
 networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,17 +17,29 @@ x-postgres: &default-postgres
       source: ./scripts/init.sql
       target: /docker-entrypoint-initdb.d/init.sql
 
+# Default configuration for redis
+x-redis: &default-redis
+  image: redis:${REDIS_VERSION-8}
+  networks:
+    - kiosc-public
+  restart: unless-stopped
+  volumes:
+    - type: bind
+      source: ./volumes/redis/data
+      target: /data
+
 # Default configuration for Docker registry
 x-kiosc-registry: &default-registry
   image: registry:3
-  container_name: kiosc-registry
-  restart: unless-stopped
   environment: &default-registry-environment
-    REGISTRY_NOTIFICATIONS_ENDPOINTS_0_HEADERS_AUTHORIZATION: "[\"Bearer ${KIOSC_CUSTOM_REGISTRY_NOTIFICATIONS_TOKEN}\"]"
     REGISTRY_HTTP_SECRET: ${KIOSC_CUSTOM_REGISTRY_HTTP_SECRET}
+    REGISTRY_NOTIFICATIONS_ENDPOINTS_0_HEADERS_AUTHORIZATION: "[\"Bearer ${KIOSC_CUSTOM_REGISTRY_NOTIFICATIONS_TOKEN}\"]"
+    REGISTRY_NOTIFICATIONS_ENDPOINTS_0_URL: "${KIOSC_CUSTOM_REGISTRY_NOTIFICATIONS_URL}"
+    REGISTRY_REDIS_ADDRS: "[${KIOSC_REDIS_URL}]"
+  restart: unless-stopped
   volumes:
     - type: bind
-      source: /var/lib/docker/registry
+      source: ./volumes/registry
       target: /var/lib/registry
     - type: bind
       source: ./config/registry/config.yml
@@ -49,11 +61,11 @@ x-kiosc: &default-kiosc
     KIOSC_DOCKER_ACTION_MIN_DELAY: ${KIOSC_DOCKER_ACTION_MIN_DELAY}
     KIOSC_DOCKER_MAX_INACTIVITY: ${KIOSC_DOCKER_MAX_INACTIVITY}
     KIOSC_DOCKER_NETWORK: ${KIOSC_DOCKER_NETWORK}
-    KIOSC_DOCKER_WEB_SERVER: ${KIOSC_DOCKER_WEB_SERVER}
     KIOSC_EMBEDDED_FILES: ${KIOSC_EMBEDDED_FILES}
     KIOSC_NETWORK_MODE: ${KIOSC_NETWORK_MODE}
     KIOSC_DATA_UPLOAD_MAX_MEMORY_SIZE: ${KIOSC_DATA_UPLOAD_MAX_MEMORY_SIZE}
-    KIOSC_CUSTOM_REGISTRY_URL: ${KIOSC_CUSTOM_REGISTRY_URL}
+    KIOSC_CUSTOM_REGISTRY_HTTP_URL: ${KIOSC_CUSTOM_REGISTRY_HTTP_URL}
+    KIOSC_CUSTOM_REGISTRY_DOCKER_URL: ${KIOSC_CUSTOM_REGISTRY_DOCKER_URL}
     KIOSC_CUSTOM_REGISTRY_NOTIFICATIONS_TOKEN: ${KIOSC_CUSTOM_REGISTRY_NOTIFICATIONS_TOKEN}
     CELERY_BROKER_URL: ${KIOSC_CELERY_BROKER_URL}
     UVICORN_WORKERS: ${KIOSC_UVICORN_WORKERS}
@@ -128,6 +140,8 @@ x-kiosc: &default-kiosc
     PROJECTROLES_TEMPLATE_INCLUDE_PATH: ${KIOSC_PROJECTROLES_TEMPLATE_INCLUDE_PATH}
   env_file:
     - .env
+  networks:
+    - kiosc-public
   restart: unless-stopped
   volumes:
     - type: bind
@@ -147,26 +161,38 @@ services:
       - "5432:5432"
 
   redis:
-    image: redis:${REDIS_VERSION-8}
-    profiles: [deploy, dev]
-    networks:
-      - kiosc-public
-    restart: unless-stopped
-    volumes:
-      - type: bind
-        source: ./volumes/redis/data
-        target: /data
+    <<: *default-redis
+    profiles: [deploy]
+
+  redis-dev:
+    <<: *default-redis
+    profiles: [dev]
+    ports:
+      - "6379:6379"
 
   kiosc-registry:
     <<: *default-registry
-    environment:
-      <<: *default-registry-environment
-      REGISTRY_NOTIFICATIONS_ENDPOINTS_0_URL: "http://127.0.0.1:8080/containers/registry"
-    profiles: [deploy, dev]
-    ports:
-      - 5000:5000
     networks:
       - kiosc-public
+    ports:
+      - "5000:5000"
+    profiles: [deploy]
+    depends_on:
+      - redis
+
+  kiosc-registry-dev:
+    <<: *default-registry
+    environment:
+      <<: *default-registry-environment
+      REGISTRY_HTTP_DEBUG_ADDR: ":5001"
+      REGISTRY_LOG_LEVEL: "debug"
+    # Need to be in the host network in order to access the kiosc-web server
+    network_mode: host
+    extra_hosts:
+      - "kiosc-web:127.0.0.1"
+    profiles: [dev]
+    depends_on:
+      - redis-dev
 
   traefik:
     image: traefik:${TRAEFIK_VERSION-v3}
@@ -195,7 +221,6 @@ services:
   kiosc-web:
     <<: *default-kiosc
     profiles: [deploy]
-    network_mode: service:kiosc-registry
     restart: unless-stopped
     depends_on:
       - postgres
@@ -206,14 +231,12 @@ services:
       - "traefik.http.routers.kiosc-web.entrypoints=web,websecure"
       - "traefik.http.routers.kiosc-web.middlewares=xforward"
       - "traefik.http.routers.kiosc-web.rule=HostRegexp(`.+`)"
-      - "traefik.http.services.kiosc-web.loadbalancer.server.port=8080"
+      - "traefik.http.services.kiosc-web.loadbalancer.server.port=8000"
       - "traefik.http.routers.kiosc-web.tls=true"
 
   kiosc-celerybeat:
     <<: *default-kiosc
     profiles: [deploy]
-    networks:
-      - kiosc-public
     command: ["celerybeat"]
     depends_on:
       - kiosc-web
@@ -222,8 +245,6 @@ services:
   kiosc-celeryd-default:
     <<: *default-kiosc
     profiles: [deploy]
-    networks:
-        - kiosc-public
     command: ["celeryd"]
     environment:
       <<: *default-kiosc-environment

--- a/env.example
+++ b/env.example
@@ -11,6 +11,7 @@ TRAEFIK_VERSION=v3
 # Kiosc configuration --------------------------------------------------------
 
 KIOSC_DATABASE_URL="postgresql://kiosc:kiosc@postgres/kiosc"
+KIOSC_REDIS_URL="redis://redis:6379"
 KIOSC_DJANGO_ALLOWED_HOSTS="*"
 KIOSC_DJANGO_SECRET_KEY=CHANGEMEchangemeCHANGEMEchangemeCHANGEMEchangemeCH
 KIOSC_DJANGO_SETTINGS_MODULE="config.settings.production"
@@ -86,6 +87,14 @@ KIOSC_ADMINS="First Admin:admin@example.com,Second Admin:admin2@example.com"
 
 KIOSC_LOGGING_LEVEL=ERROR
 KIOSC_LOGGING_FILE_PATH=
+
+# Kiosc custom registry settings ---------------------------------------------
+
+KIOSC_DATA_UPLOAD_MAX_MEMORY_SIZE="4294967296"
+# You must be able to reach the registry URL from the host, so if the registry runs in a docker container, either bind port 5000 or make sure that the host can resolve the container name.
+KIOSC_CUSTOM_REGISTRY_URL="http://127.0.0.1:5000"
+KIOSC_CUSTOM_REGISTRY_NOTIFICATIONS_TOKEN="PleaseChangeMeToo"
+KIOSC_CUSTOM_REGISTRY_HTTP_SECRET="ChangeMeAsWell"
 
 # Kiosc REST API settings ----------------------------------------------------
 

--- a/env.example
+++ b/env.example
@@ -16,10 +16,9 @@ KIOSC_DJANGO_ALLOWED_HOSTS="*"
 KIOSC_DJANGO_SECRET_KEY=CHANGEMEchangemeCHANGEMEchangemeCHANGEMEchangemeCH
 KIOSC_DJANGO_SETTINGS_MODULE="config.settings.production"
 
-KIOSC_DOCKER_ACTION_MIN_DELAY=7
-KIOSC_DOCKER_MAX_INACTIVITY=1
+KIOSC_DOCKER_ACTION_MIN_DELAY=1
+KIOSC_DOCKER_MAX_INACTIVITY=5
 KIOSC_DOCKER_NETWORK=kiosc-net
-KIOSC_DOCKER_WEB_SERVER=kiosc-web
 KIOSC_EMBEDDED_FILES=1
 KIOSC_NETWORK_MODE=docker-shared
 
@@ -90,11 +89,12 @@ KIOSC_LOGGING_FILE_PATH=
 
 # Kiosc custom registry settings ---------------------------------------------
 
-KIOSC_DATA_UPLOAD_MAX_MEMORY_SIZE="4294967296"
-# You must be able to reach the registry URL from the host, so if the registry runs in a docker container, either bind port 5000 or make sure that the host can resolve the container name.
-KIOSC_CUSTOM_REGISTRY_URL="http://127.0.0.1:5000"
+KIOSC_CUSTOM_REGISTRY_HTTP_URL="http://kiosc-registry:5000"
+KIOSC_CUSTOM_REGISTRY_DOCKER_URL="127.0.0.1:5000"
+KIOSC_CUSTOM_REGISTRY_NOTIFICATIONS_URL="http://kiosc-web:8000/registry"
 KIOSC_CUSTOM_REGISTRY_NOTIFICATIONS_TOKEN="PleaseChangeMeToo"
 KIOSC_CUSTOM_REGISTRY_HTTP_SECRET="ChangeMeAsWell"
+KIOSC_DATA_UPLOAD_MAX_MEMORY_SIZE="4294967296"
 
 # Kiosc REST API settings ----------------------------------------------------
 


### PR DESCRIPTION
This PR adds a self-hosted Docker registry to the Kiosc Docker compose stack. Corresponding changes in kiosc-server v0.6 will make use of this new component allowing users to push images directly to this registry after authenticating with their Kiosc credentials.

Two additional changes were made to simplify the set up:
- The redis service was split into redis and redis-dev
- The kiosc-web port was changed from 8080 to 8000 (see https://github.com/bihealth/kiosc-server/pull/228)